### PR TITLE
Show and Prioritize Android SDK Errors 

### DIFF
--- a/src/main/java/gdx/liftoff/ui/panels/PathsPanel.java
+++ b/src/main/java/gdx/liftoff/ui/panels/PathsPanel.java
@@ -121,12 +121,7 @@ public class PathsPanel extends Table implements Panel {
             return;
         }
 
-        if (tempFileHandle.list().length != 0) {
-            errorLabel.setText(prop.getProperty("notEmptyDirectory"));
-            return;
-        }
-
-        boolean android = UserData.platforms.contains(prop.getProperty("android"));
+        boolean android = UserData.platforms.contains("android");
         if (android && (UserData.androidPath == null || UserData.androidPath.isEmpty())) {
             errorLabel.setText(prop.getProperty("sdkNullDirectory"));
             return;
@@ -140,6 +135,11 @@ public class PathsPanel extends Table implements Panel {
 
         if (android && !Main.isAndroidSdkDirectory(UserData.androidPath)) {
             errorLabel.setText(prop.getProperty("invalidSdkDirectory"));
+            return;
+        }
+
+        if (tempFileHandle.list().length != 0) {
+            errorLabel.setText(prop.getProperty("notEmptyDirectory"));
             return;
         }
 

--- a/src/main/java/gdx/liftoff/ui/panels/PathsPanel.java
+++ b/src/main/java/gdx/liftoff/ui/panels/PathsPanel.java
@@ -138,6 +138,7 @@ public class PathsPanel extends Table implements Panel {
             return;
         }
 
+        tempFileHandle = Gdx.files.absolute(UserData.projectPath);
         if (tempFileHandle.list().length != 0) {
             errorLabel.setText(prop.getProperty("notEmptyDirectory"));
             return;


### PR DESCRIPTION
Android SDK errors were not showing because of the familiar issue with the line `boolean android = UserData.platforms.contains(prop.getProperty("android"));`

They also weren't prioritized over the "notEmptyDirectory" warning, which obscures why "generate" is disabled. I resolved both of these issues.