### PR TITLE
Hide robovm version if ios not selected.

### DIFF
--- a/src/main/java/gdx/liftoff/ui/panels/SettingsPanel.java
+++ b/src/main/java/gdx/liftoff/ui/panels/SettingsPanel.java
@@ -46,8 +46,11 @@ public class SettingsPanel extends Table implements Panel {
         onChange(applicationTextField, () -> UserData.libgdxVersion = applicationTextField.getText());
 
         //robovm version
-        TextField robovmTextField = addField(prop.getProperty("robovmVersion"), prop.getProperty("robovmVersionTip"), UserData.robovmVersion, table);
-        onChange(robovmTextField, () -> UserData.libgdxVersion = robovmTextField.getText());
+        if (UserData.platforms.contains("ios")) {
+            TextField robovmTextField = addField(prop.getProperty("robovmVersion"),
+                prop.getProperty("robovmVersionTip"), UserData.robovmVersion, table);
+            onChange(robovmTextField, () -> UserData.libgdxVersion = robovmTextField.getText());
+        }
 
         //add gui assets
         table.defaults().spaceTop(SPACE_MEDIUM);


### PR DESCRIPTION
If the user does not select the iOS platform, the RoboVM version field is not shown in the settings panel. This is confirmed to work in the standard and maximized work flows.