### PR TITLE
Fix incorrect count in ThirdPartyPanel

### DIFF
--- a/src/main/java/gdx/liftoff/Main.java
+++ b/src/main/java/gdx/liftoff/Main.java
@@ -472,7 +472,7 @@ public class Main extends ApplicationAdapter {
 
         extensions = splitCSV(pref.getString("Extensions", prop.getProperty("extensionsDefaultNames")));
         UserData.template = prop.getProperty("templateDefaultName");
-        UserData.thirdPartyLibs = splitCSV(pref.getString("ThirdParty", prop.getProperty("thirdPartyDefaultNames")));
+        UserData.thirdPartyLibs = splitCSV(pref.getString("ThirdPartyLibs", prop.getProperty("thirdPartyDefaultNames")));
         UserData.libgdxVersion = prop.getProperty("libgdxDefaultVersion");
         UserData.javaVersion = prop.getProperty("javaDefaultVersion");
         appVersion = prop.getProperty("appDefaultVersion");

--- a/src/main/java/gdx/liftoff/ui/panels/ThirdPartyPanel.java
+++ b/src/main/java/gdx/liftoff/ui/panels/ThirdPartyPanel.java
@@ -146,7 +146,7 @@ public class ThirdPartyPanel extends Table implements Panel {
                 if (checkBox.isChecked() && !UserData.thirdPartyLibs.contains(searchEntry.id))
                     UserData.thirdPartyLibs.add(searchEntry.id);
                 else UserData.thirdPartyLibs.remove(searchEntry.id);
-                pref.putString("ThirdParty", String.join(",", UserData.thirdPartyLibs));
+                pref.putString("ThirdPartyLibs", String.join(",", UserData.thirdPartyLibs));
                 pref.flush();
                 updateFilterCheckBox();
             });


### PR DESCRIPTION
The number of selected third-party libs in the ThirdPartyPanel shows an incorrect value if the user has used previous versions of liftoff. This corrects that issue.