### PR TITLE
High dpi fixes

### DIFF
--- a/src/main/java/gdx/liftoff/Main.java
+++ b/src/main/java/gdx/liftoff/Main.java
@@ -78,6 +78,7 @@ public class Main extends ApplicationAdapter {
     private static final GlyphLayout layout = new GlyphLayout();
     public static final int MIN_WINDOW_WIDTH = 400;
     public static final int MIN_WINDOW_HEIGHT = 410;
+    public static final int WINDOW_BORDER = 50;
     public static final float FULLSCREEN_MIN_WIDTH = 1500;
     public static final float FULLSCREEN_MIN_HEIGHT = 880;
     public static final float ROOT_TABLE_PREF_WIDTH = 600;
@@ -108,9 +109,11 @@ public class Main extends ApplicationAdapter {
         config.setIdleFPS(8);
 
         DisplayMode primaryDesktopMode = Lwjgl3ApplicationConfiguration.getDisplayMode();
-        int width = Math.max(MathUtils.round(primaryDesktopMode.width / 1920f * 800f), 800);
-        int height = Math.max(MathUtils.round(primaryDesktopMode.height / 1080f * 800f), 800);
-        config.setWindowedMode(width, height);
+        int monitorWidth = primaryDesktopMode.width;
+        int monitorHeight=  primaryDesktopMode.height;
+        int windowWidth = Math.max(MathUtils.round(monitorWidth / 1920f * 800f), 800);
+        int windowHeight = Math.max(MathUtils.round(monitorHeight / 1080f * 800f), 800);
+        config.setWindowedMode(Math.min(windowWidth, monitorWidth - WINDOW_BORDER * 2), Math.min(windowHeight, monitorHeight - WINDOW_BORDER * 2));
 
         config.setWindowSizeLimits(MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT, -1, -1);
         config.setWindowIcon("icons/libgdx128.png", "icons/libgdx64.png", "icons/libgdx32.png", "icons/libgdx16.png");

--- a/src/main/java/gdx/liftoff/Main.java
+++ b/src/main/java/gdx/liftoff/Main.java
@@ -71,6 +71,7 @@ public class Main extends ApplicationAdapter {
     public static Image bgImage = new Image();
     public static boolean resizingWindow;
     public static boolean generatingProject;
+    public static String latestStableVersion;
     public static Properties prop;
     public static Preferences pref;
     private static final GlyphLayout layout = new GlyphLayout();
@@ -715,10 +716,12 @@ public class Main extends ApplicationAdapter {
         HttpResponseListener listener = new HttpResponseListener() {
             @Override
             public void handleHttpResponse(HttpResponse httpResponse) {
-                String latestStable = httpResponse.getResultAsString().trim();
-                if (!prop.getProperty("liftoffVersion").equals(latestStable)) {
+                latestStableVersion = httpResponse.getResultAsString().trim();
+                if (!prop.getProperty("liftoffVersion").equals(latestStableVersion)) {
                     Gdx.app.postRunnable(() -> {
+                        System.out.println("hit");
                         root.landingTable.animateUpdateLabel();
+                        if (fullscreenDialog != null) fullscreenDialog.updateVersion();
                     });
                 }
             }

--- a/src/main/java/gdx/liftoff/Main.java
+++ b/src/main/java/gdx/liftoff/Main.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.ApplicationAdapter;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics.DisplayMode;
 import com.badlogic.gdx.Graphics.Monitor;
+import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.Net.HttpRequest;
 import com.badlogic.gdx.Net.HttpResponse;
 import com.badlogic.gdx.Net.HttpResponseListener;
@@ -126,10 +127,13 @@ public class Main extends ApplicationAdapter {
             @Override
             public void maximized(boolean isMax) {
                 if (isMax){
-                    if(root != null) {
-                        if (root.getCurrentTable() == root.completeTable) FullscreenCompleteDialog.show(false);
-                        else FullscreenDialog.show();
-                        root.fadeOutTable();
+                    if (root != null) {
+                        Gdx.app.postRunnable(() -> {
+                            root.getCurrentTable().finishAnimation();
+                            if (root.getCurrentTable() == root.completeTable) FullscreenCompleteDialog.show(false);
+                            else FullscreenDialog.show();
+                            root.fadeOutTable();
+                        });
                     }
                     if(overlayTable != null)
                         overlayTable.fadeOut();
@@ -247,6 +251,7 @@ public class Main extends ApplicationAdapter {
         stage.draw();
 
         resizingWindow = false;
+        if (Gdx.input.isKeyJustPressed(Keys.F5)) FullscreenDialog.show();
     }
 
     @Override

--- a/src/main/java/gdx/liftoff/Main.java
+++ b/src/main/java/gdx/liftoff/Main.java
@@ -78,6 +78,8 @@ public class Main extends ApplicationAdapter {
     private static final GlyphLayout layout = new GlyphLayout();
     public static final int MIN_WINDOW_WIDTH = 400;
     public static final int MIN_WINDOW_HEIGHT = 410;
+    public static final float FULLSCREEN_MIN_WIDTH = 1500;
+    public static final float FULLSCREEN_MIN_HEIGHT = 880;
     public static final float ROOT_TABLE_PREF_WIDTH = 600;
     public static final float ROOT_TABLE_PREF_HEIGHT = 700;
 
@@ -127,7 +129,9 @@ public class Main extends ApplicationAdapter {
             @Override
             public void maximized(boolean isMax) {
                 if (isMax){
-                    if (root != null) {
+                    boolean fullscreenMode = Gdx.graphics.getWidth() > FULLSCREEN_MIN_WIDTH &&
+                        Gdx.graphics.getHeight() > FULLSCREEN_MIN_HEIGHT;
+                    if (fullscreenMode && root != null) {
                         Gdx.app.postRunnable(() -> {
                             root.getCurrentTable().finishAnimation();
                             if (root.getCurrentTable() == root.completeTable) FullscreenCompleteDialog.show(false);
@@ -135,7 +139,7 @@ public class Main extends ApplicationAdapter {
                             root.fadeOutTable();
                         });
                     }
-                    if(overlayTable != null)
+                    if(fullscreenMode && overlayTable != null)
                         overlayTable.fadeOut();
                 } else {
                     if (fullscreenDialog != null)

--- a/src/main/java/gdx/liftoff/Main.java
+++ b/src/main/java/gdx/liftoff/Main.java
@@ -228,7 +228,10 @@ public class Main extends ApplicationAdapter {
 
         checkSetupVersion();
 
-        if (pref.getBoolean("startMaximized", false)) {
+        DisplayMode primaryDesktopMode = Lwjgl3ApplicationConfiguration.getDisplayMode();
+        int width = primaryDesktopMode.width;
+        int height = primaryDesktopMode.height;
+        if (!pref.contains("startMaximized") && width > 1920 && height > 1080 || pref.getBoolean("startMaximized", false)) {
             Main.maximizeWindow();
         }
     }

--- a/src/main/java/gdx/liftoff/Main.java
+++ b/src/main/java/gdx/liftoff/Main.java
@@ -2,6 +2,8 @@ package gdx.liftoff;
 
 import com.badlogic.gdx.ApplicationAdapter;
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics.DisplayMode;
+import com.badlogic.gdx.Graphics.Monitor;
 import com.badlogic.gdx.Net.HttpRequest;
 import com.badlogic.gdx.Net.HttpResponse;
 import com.badlogic.gdx.Net.HttpResponseListener;
@@ -12,6 +14,7 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Cursor.SystemCursor;
 import com.badlogic.gdx.graphics.g2d.GlyphLayout;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.net.HttpRequestBuilder;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
@@ -99,7 +102,12 @@ public class Main extends ApplicationAdapter {
         config.useVsync(true);
         config.setForegroundFPS(Lwjgl3ApplicationConfiguration.getDisplayMode().refreshRate);
         config.setIdleFPS(8);
-        config.setWindowedMode(800, 800);
+
+        DisplayMode primaryDesktopMode = Lwjgl3ApplicationConfiguration.getDisplayMode();
+        int width = Math.max(MathUtils.round(primaryDesktopMode.width / 1920f * 800f), 800);
+        int height = Math.max(MathUtils.round(primaryDesktopMode.height / 1080f * 800f), 800);
+        config.setWindowedMode(width, height);
+
         config.setWindowSizeLimits(MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT, -1, -1);
         config.setWindowIcon("icons/libgdx128.png", "icons/libgdx64.png", "icons/libgdx32.png", "icons/libgdx16.png");
         config.setAutoIconify(true);

--- a/src/main/java/gdx/liftoff/Main.java
+++ b/src/main/java/gdx/liftoff/Main.java
@@ -255,7 +255,6 @@ public class Main extends ApplicationAdapter {
         stage.draw();
 
         resizingWindow = false;
-        if (Gdx.input.isKeyJustPressed(Keys.F5)) FullscreenDialog.show();
     }
 
     @Override

--- a/src/main/java/gdx/liftoff/ui/LogoWidget.java
+++ b/src/main/java/gdx/liftoff/ui/LogoWidget.java
@@ -17,7 +17,7 @@ import static gdx.liftoff.Main.*;
  * spaces.
  */
 public class LogoWidget extends Table {
-    public LogoWidget() {
+    public LogoWidget(boolean showVersion) {
         CollapsibleGroup verticalCollapsibleGroup = new CollapsibleGroup(CollapseType.VERTICAL);
         add(verticalCollapsibleGroup).minHeight(0);
 
@@ -42,12 +42,14 @@ public class LogoWidget extends Table {
         container.padTop(SPACE_MEDIUM);
         verticalCollapsibleGroup.addActor(container);
 
-        //version
-        Label label = new Label("v" + prop.getProperty("liftoffVersion"), skin);
-        label.setEllipsis("...");
-        container.setActor(label);
+        if (showVersion) {
+            //version
+            Label label = new Label("v" + prop.getProperty("liftoffVersion"), skin);
+            label.setEllipsis("...");
+            container.setActor(label);
 
-        container = new Container<>();
-        verticalCollapsibleGroup.addActor(container);
+            container = new Container<>();
+            verticalCollapsibleGroup.addActor(container);
+        }
     }
 }

--- a/src/main/java/gdx/liftoff/ui/dialogs/FullscreenDialog.java
+++ b/src/main/java/gdx/liftoff/ui/dialogs/FullscreenDialog.java
@@ -71,11 +71,11 @@ public class FullscreenDialog extends PopTable {
 
         //logo
         LogoWidget logoWidget = new LogoWidget(false);
-        table.add(logoWidget).minHeight(Value.prefHeight);
+        table.add(logoWidget).minHeight(Value.prefHeight).spaceBottom(0);
 
         contentTable.row();
         table = new Table();
-        contentTable.add(table).growX();
+        contentTable.add(table).growX().spaceTop(0);
 
         //new project title
         table.defaults().space(SPACE_MEDIUM);

--- a/src/main/java/gdx/liftoff/ui/dialogs/FullscreenDialog.java
+++ b/src/main/java/gdx/liftoff/ui/dialogs/FullscreenDialog.java
@@ -1,5 +1,6 @@
 package gdx.liftoff.ui.dialogs;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
 import com.badlogic.gdx.scenes.scene2d.ui.Window.WindowStyle;
@@ -23,6 +24,7 @@ import static gdx.liftoff.Main.*;
 public class FullscreenDialog extends PopTable {
     public static FullscreenDialog fullscreenDialog;
     private TextButton generateButton;
+    private Table versionTable;
 
     public FullscreenDialog() {
         super(skin.get("fullscreen", WindowStyle.class));
@@ -135,14 +137,31 @@ public class FullscreenDialog extends PopTable {
         )));
 
         //version
-        label = new Label("v" + prop.getProperty("liftoffVersion"), skin);
-        table.add(label).expandX().right().bottom().uniformX();
+        versionTable = new Table();
+        table.add(versionTable).expandX().right().bottom().uniformX();
+        updateVersion();
     }
 
     @Override
     public void hide(Action action) {
         super.hide(action);
         fullscreenDialog = null;
+    }
+
+    public void updateVersion() {
+        versionTable.clearChildren();
+
+        Label label = new Label("v" + prop.getProperty("liftoffVersion"), skin);
+        versionTable.add(label);
+
+        if (latestStableVersion != null && !prop.getProperty("liftoffVersion").equals(latestStableVersion)) {
+            versionTable.row();
+            TextButton updateButton = new TextButton(prop.getProperty("updateAvailable"), skin, "link");
+            versionTable.add(updateButton);
+            addHandListener(updateButton);
+            addTooltip(updateButton, Align.top, prop.getProperty("updateTip"));
+            onChange(updateButton, () -> Gdx.net.openURI(prop.getProperty("updateUrl")));
+        }
     }
 
     public static void show() {

--- a/src/main/java/gdx/liftoff/ui/dialogs/FullscreenDialog.java
+++ b/src/main/java/gdx/liftoff/ui/dialogs/FullscreenDialog.java
@@ -64,13 +64,13 @@ public class FullscreenDialog extends PopTable {
     }
 
     private void createPanels(Table contentTable) {
-        contentTable.defaults().space(SPACE_HUGE);
+        contentTable.defaults().space(SPACE_SMALL);
         Table table = new Table();
         contentTable.add(table).growX();
         table.setTransform(true);
 
         //logo
-        LogoWidget logoWidget = new LogoWidget();
+        LogoWidget logoWidget = new LogoWidget(false);
         table.add(logoWidget).minHeight(Value.prefHeight);
 
         contentTable.row();

--- a/src/main/java/gdx/liftoff/ui/panels/CompletePanel.java
+++ b/src/main/java/gdx/liftoff/ui/panels/CompletePanel.java
@@ -23,7 +23,7 @@ public class CompletePanel extends Table implements Panel {
         clearChildren();
         //logo
         defaults().space(SPACE_MEDIUM);
-        LogoWidget logo = new LogoWidget();
+        LogoWidget logo = new LogoWidget(true);
         add(logo);
 
         //title


### PR DESCRIPTION
This addresses a few issues that affect the fullscreen dialog and users of high-DPI screens (4K, 8K, etc.)
* The default window size is scaled up for larger screens
* The app is maximized by default if the screen is larger than 1920x1080. 1920x1080 is used as the guideline because that is the screen size that the normal mode was designed for
* The update button was missing from the fullscreen dialog. It has been added so users that start maximized will still see it.
* The minSize for the fullscreen layout has been made smaller to prevent the scrollpane from being activated on smaller screens
* I noticed that keyboard focus was being stolen when starting the app maximized. This has been fixed.
* Smaller screens will not activate the fullscreen dialog if they are too small to show the entire layout without adding a scrollpane. They will just use the normal mode while the window is maximized. This has been opted for because scaling down everything in the fullscreen dialog creates unacceptable pixel rounding errors.