### PR TITLE
Fix switching from fullscreen to normal errors

### DIFF
--- a/src/main/java/gdx/liftoff/Main.java
+++ b/src/main/java/gdx/liftoff/Main.java
@@ -145,20 +145,23 @@ public class Main extends ApplicationAdapter {
                     if(fullscreenMode && overlayTable != null)
                         overlayTable.fadeOut();
                 } else {
-                    if (fullscreenDialog != null)
+                    if (fullscreenDialog != null) {
                         fullscreenDialog.hide();
-                    if (fullscreenCompleteDialog != null) {
+                        root.getCurrentTable().populate();
+                        root.fadeInTable();
+                        overlayTable.fadeIn();
+                    } else if (fullscreenCompleteDialog != null) {
                         fullscreenCompleteDialog.hide();
                         if (root != null) {
                             root.fadeInTable();
-                            root.showTableInstantly(root.completeTable);
-                            root.completeTable.showCompletePanel();
+                            overlayTable.fadeIn();
+
+                            if (root.getCurrentTable() != root.completeTable) {
+                                root.showTableInstantly(root.completeTable);
+                                root.completeTable.showCompletePanel();
+                            }
                         }
                     }
-                    if (root != null)
-                        root.fadeInTable();
-                    if (overlayTable != null)
-                        overlayTable.fadeIn();
                 }
                 pref.putBoolean("startMaximized", isMax);
                 pref.flush();

--- a/src/main/java/gdx/liftoff/ui/panels/CompleteButtonsPanel.java
+++ b/src/main/java/gdx/liftoff/ui/panels/CompleteButtonsPanel.java
@@ -19,7 +19,7 @@ import static gdx.liftoff.Main.*;
 
 /**
  * The table to display the buttons to create a new project, open the project in IDEA, or exit the application after
- * project generation is complete. This panel is intended for use only in the normal and quick project workflows.
+ * project generation is complete.
  */
 public class CompleteButtonsPanel extends Table implements Panel {
     /**
@@ -52,6 +52,7 @@ public class CompleteButtonsPanel extends Table implements Panel {
             onChange(textButton, () -> {
                 popTable.hide();
                 FullscreenDialog.show();
+                root.showTableInstantly(root.landingTable);
             });
         }
 


### PR DESCRIPTION
This PR resolves a few things:
* The fields in the panels are not updated when switching from fullscreen to normal
* Maximizing and restoring a couple times while viewing the CompleteFullscreenDialog results in the normal table staying invisible
* After generating the project files in the FullscreenDialog, then clicking "New Project", when you restore the window it will show the project generation animation again in certain circumstances